### PR TITLE
Fix exclusive reactions

### DIFF
--- a/aod-discord-bot.js
+++ b/aod-discord-bot.js
@@ -668,7 +668,7 @@ function getParams(string) {
 function notifyRequestError(message, member, guild, error, showError) {
 	if (!error)
 		return;
-	console.error(`Error from ${__caller_function}:${__caller_line}: ${error.toString()}`);
+	console.error('An error occurred while processing your request: ' + error.toString());
 	if (showError && message) {
 		if (member)
 			member.send('An error occurred while processing your request: ' + message.content + "\n" + error.toString())

--- a/api/api.js
+++ b/api/api.js
@@ -145,7 +145,8 @@ messageRouter.post('/:message_id/react', async (req, res, next) => {
 					return;
 				}
 				await req.message.reactions.removeAll();
-			} else if (reaction && reaction.users.resolve(global.client.user.id)) {
+			}
+			if (reaction && reaction.users.resolve(global.client.user.id)) {
 				await reaction.users.remove(global.client.user.id).catch(() => {});
 			} else {
 				reaction = await req.message.react(emojiId).catch((err) => {});

--- a/api/api.js
+++ b/api/api.js
@@ -138,17 +138,17 @@ messageRouter.post('/:message_id/react', async (req, res, next) => {
 			res.status(404).send({ error: 'Unknown emoji' });
 		} else {
 			let reaction = req.message.reactions.cache.get(emojiId);
-			if (req.body.exclusive) {
-				if (req.message.author.id !== global.client.user.id) {
-					res.status(403).send({ error: 'Cannot clear reactions on messages authored by other users' });
-					next();
-					return;
-				}
-				await req.message.reactions.removeAll();
-			}
 			if (reaction && reaction.users.resolve(global.client.user.id)) {
 				await reaction.users.remove(global.client.user.id).catch(() => {});
 			} else {
+				if (req.body.exclusive) {
+					if (req.message.author.id !== global.client.user.id) {
+						res.status(403).send({ error: 'Cannot clear reactions on messages authored by other users' });
+						next();
+						return;
+					}
+					await req.message.reactions.removeAll();
+				}
 				reaction = await req.message.react(emojiId).catch((err) => {});
 				if (!reaction) {
 					res.status(500).send({ error: `Failed to add reaction` });


### PR DESCRIPTION
Restructure the reaction handler so reactions are properly applied when the `exclusive` flag is set. Previously the old reactions were removed but the logic to apply the new reaction was skipped.

I also removed references to old error logging variables to facilitate local development when not connected to the full forum and tracker DB.