### PR TITLE
Don't display null if no reason is provided with built-in kick/ban.

### DIFF
--- a/aod-discord-bot.js
+++ b/aod-discord-bot.js
@@ -4798,6 +4798,7 @@ client.on('guildAuditLogEntryCreate', async function(auditLogEntry, guild) {
 		if (executor === client.user)
 			return;
 
+		reason = reason ?? 'No reason provided';
 		const actionDescription = {
 			[AuditLogEvent.MemberKick]: "kicked",
 			[AuditLogEvent.MemberBanAdd]: "banned",


### PR DESCRIPTION
Basically, prevent this:

`<@User> has been kicked by <@OtherUser> for: null`