### PR TITLE
Fixed undefined member update reasons/descriptions

### DIFF
--- a/aod-discord-bot.js
+++ b/aod-discord-bot.js
@@ -4253,17 +4253,18 @@ client.on('guildAuditLogEntryCreate', async function(auditLogEntry, guild) {
 				}
 			});
 
-			if (actionDescription === undefined)
+			if (actionDescription === undefined) {
+				console.log(`Unsupported MemberUpdate on ${auditLogEntry.target.username} by ${auditLogEntry.executor.username}: ${JSON.stringify(auditLogEntry.changes)}`);
 				return;
+			}
+
 			break;
 		default:
 			return;
 	}
 
 	let reason = auditLogEntry.reason ?? 'No reason provided';
-	let executor = await client.users.fetch(auditLogEntry.executorId);
-	let target = await client.users.fetch(auditLogEntry.targetId);
-	await global.sendGlobalNotification(guild, `${target} has been ${actionDescription} by ${executor} for: ${reason}`);
+	await global.sendGlobalNotification(guild, `${auditLogEntry.target} has been ${actionDescription} by ${auditLogEntry.executor} for: ${reason}`);
 });
 
 //guildCreate handler -- triggers when the bot joins a server for the first time

--- a/aod-discord-bot.js
+++ b/aod-discord-bot.js
@@ -4251,6 +4251,9 @@ client.on('guildAuditLogEntryCreate', async function(auditLogEntry, guild) {
 					}
 				}
 			});
+
+			if (actionDescription === undefined)
+				return;
 			break;
 		default:
 			return;

--- a/aod-discord-bot.js
+++ b/aod-discord-bot.js
@@ -4068,7 +4068,7 @@ global.setRolesForMember = setRolesForMember;
 //guildMemberAdd event handler -- triggered when a user joins the guild
 client.on('guildMemberAdd', member => {
 	setRolesForMember(member.guild, member, 'First time join')
-		.catch(console.error);
+		.catch(console.log);
 });
 
 function checkAddDependentRoles(guild, role, member) {

--- a/aod-discord-bot.js
+++ b/aod-discord-bot.js
@@ -4067,7 +4067,8 @@ global.setRolesForMember = setRolesForMember;
 
 //guildMemberAdd event handler -- triggered when a user joins the guild
 client.on('guildMemberAdd', member => {
-	setRolesForMember(member.guild, member, 'First time join');
+	setRolesForMember(member.guild, member, 'First time join')
+		.catch(console.error);
 });
 
 function checkAddDependentRoles(guild, role, member) {


### PR DESCRIPTION
Verify a human-readable `actionDescription` is available before sending audit notifications for a MemberUpdate event. This prevents alerts for member update events other than timeouts. 