### PR TITLE
Expose role-feed channel permission

### DIFF
--- a/commands/channel.js
+++ b/commands/channel.js
@@ -18,6 +18,7 @@ const typeChoices = [
 
 const permChoices = [
 	{ name: 'Feed', value: 'feed' },
+	{ name: 'Feed (Role Locked)', value: 'role-feed' },
 	{ name: 'Public', value: 'public' },
 	{ name: 'Guest+', value: 'guest' },
 	{ name: 'Member+', value: 'member' },


### PR DESCRIPTION
Expose the role-feed channel permission template in the command autocomplete. 