### PR TITLE
Add member update API

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -467,6 +467,23 @@ memberRouter.get('/:member_id', async (req, res, next) => {
 	next();
 });
 
+memberRouter.get('/:member_id/update', async (req, res, next) => {
+	if (res.writableEnded) {
+		//do nothing if response already sent
+		next();
+		return;
+	}
+
+	try {
+		await global.setRolesForMember(req.guild, req.member, 'Requested by API');
+		res.send({ status: 'Member update complete' });
+	} catch (error) {
+		res.status(500).send({ error: 'Failed to run member update' });
+	}
+
+	next();
+});
+
 memberRouter.post('/:member_id', async (req, res, next) => {
 	if (res.writableEnded) {
 		//do nothing if response already sent


### PR DESCRIPTION
This adds the `GET API/member/:member_id/update` API to be called by Tracker to force an ad-hoc member sync.