### PR TITLE
Add forum ID to Forum Data output

### DIFF
--- a/commands/who.js
+++ b/commands/who.js
@@ -237,7 +237,7 @@ module.exports = {
 				let data = userData[i];
 				embed.fields.push({
 					name: 'Forum Data',
-					value: `**Username**: ${data.name}\n` +
+					value: `**Username**: ${data.name} (${data.id})\n` +
 						`**Division**: ${data.division}\n` +
 						`**Rank**: ${data.rank}\n` +
 						`**Status**: ${data.loaStatus}\n` +


### PR DESCRIPTION
Adds the forum ID to the `/who` output under Forum Data. This reduces the number of steps required to initiate a recruitment in Tracker depending on division procedures. 