### PR TITLE
Add button to set voice channel status to JTC

### DIFF
--- a/commands/channel.js
+++ b/commands/channel.js
@@ -654,8 +654,8 @@ module.exports = {
 					return global.ephemeralReply(interaction, 'JTC must be in a division category.');
 				}
 
-				const channelInfo = await global.getChannelInfo(guild, channel);
 				if (createdBy != member.id) {
+					const channelInfo = await global.getChannelInfo(guild, channel);
 					if (perm < global.PERM_MOD && !member.roles.cache.has(channelInfo.details.officer.role.id)) {
 						return global.ephemeralReply(interaction, 'You are not the channel owner.');
 					}

--- a/commands/channel.js
+++ b/commands/channel.js
@@ -655,14 +655,10 @@ module.exports = {
 				}
 
 				const channelInfo = await global.getChannelInfo(guild, channel);
-				let creator;
 				if (createdBy != member.id) {
 					if (perm < global.PERM_MOD && !member.roles.cache.has(channelInfo.details.officer.role.id)) {
 						return global.ephemeralReply(interaction, 'You are not the channel owner.');
 					}
-					creator = guild.members.resolve(createdBy);
-				} else {
-					creator = member;
 				}
 
 				let topic = interaction.fields.getTextInputValue('status') ?? "";


### PR DESCRIPTION
This PR adds an additional button to JTC channels, allowing the channel owner or officer+ to set the voice channel status using a modal dialog. Some divisions have members who participate in Discord via mobile applications, which do not currently support setting voice channel status. 

Discord emojis are not supported using this method, which is a disadvantage, but this does not replace the built-in functionality on the desktop client.  

![image](https://github.com/user-attachments/assets/46bb53d8-9b0a-4f1f-b2da-c40284936d3a)

![image](https://github.com/user-attachments/assets/ffe3551e-c1be-4dee-8906-6d87b939eb27)
