### PR TITLE
Update divisions member_channel attribute

### DIFF
--- a/aod-discord-bot.js
+++ b/aod-discord-bot.js
@@ -1655,15 +1655,11 @@ function updateTrackerDivisionData(divisionData, data) {
 	return promise;
 }
 
-function updateTrackerDivisionChannels(divisionData, officersChannel, membersChannel) {
+function updateTrackerDivisionChannel(divisionData, channelType, channel) {
 	const updates = {};
 
-	if (officersChannel) {
-		updates.officer_channel = officersChannel.id;
-	}
-
-	if (membersChannel) {
-		updates.member_channel = membersChannel.id;
+	if (channel) {
+		updates[channelType] = channel.id;
 	}
 
 	if (Object.keys(updates).length === 0) {
@@ -1672,17 +1668,14 @@ function updateTrackerDivisionChannels(divisionData, officersChannel, membersCha
 
 	return updateTrackerDivisionData(divisionData, updates)
 		.then(function() {
-			if (officersChannel) {
-				divisionData.officer_channel = officersChannel.id;
-			}
-			if (membersChannel) {
-				divisionData.member_channel = membersChannel.id;
+			if (channel) {
+				divisionData[channelType] = channel.id;
 			}
 		})
 		.catch(() => {});
 }
 
-global.updateTrackerDivisionChannels = updateTrackerDivisionChannels;
+global.updateTrackerDivisionChannel = updateTrackerDivisionChannel;
 
 function updateOnboarding(guild, message) {
 	let promise = new Promise(async function(resolve, reject) {
@@ -1891,7 +1884,8 @@ async function addDivision(message, member, perm, guild, divisionName) {
 			addForumSyncMap(message, guild, config.officerRole, divisionName + ' ' + config.forumOfficerSuffix);
 		}
 		if (divisionData && officersChannel) {
-			await updateTrackerDivisionChannels(divisionData, officersChannel, membersChannel);
+			await updateTrackerDivisionChannel(divisionData, officersChannel, 'officer_channel');
+			await updateTrackerDivisionChannel(divisionData, membersChannel, 'member_channel');
 		}
 
 		if (divisionData && divisionData.icon) {

--- a/aod-discord-bot.js
+++ b/aod-discord-bot.js
@@ -1655,12 +1655,34 @@ function updateTrackerDivisionData(divisionData, data) {
 	return promise;
 }
 
-function updateTrackerDivisionOfficerChannel(divisionData, channel) {
-	return updateTrackerDivisionData(divisionData, { officer_channel: channel.id })
-		.then(function() { divisionData.officer_channel = channel.id; })
+function updateTrackerDivisionChannels(divisionData, officersChannel, membersChannel) {
+	const updates = {};
+
+	if (officersChannel) {
+		updates.officer_channel = officersChannel.id;
+	}
+
+	if (membersChannel) {
+		updates.member_channel = membersChannel.id;
+	}
+
+	if (Object.keys(updates).length === 0) {
+		return;
+	}
+
+	return updateTrackerDivisionData(divisionData, updates)
+		.then(function() {
+			if (officersChannel) {
+				divisionData.officer_channel = officersChannel.id;
+			}
+			if (membersChannel) {
+				divisionData.member_channel = membersChannel.id;
+			}
+		})
 		.catch(() => {});
 }
-global.updateTrackerDivisionOfficerChannel = updateTrackerDivisionOfficerChannel;
+
+global.updateTrackerDivisionChannels = updateTrackerDivisionChannels;
 
 function updateOnboarding(guild, message) {
 	let promise = new Promise(async function(resolve, reject) {
@@ -1869,7 +1891,7 @@ async function addDivision(message, member, perm, guild, divisionName) {
 			addForumSyncMap(message, guild, config.officerRole, divisionName + ' ' + config.forumOfficerSuffix);
 		}
 		if (divisionData && officersChannel) {
-			await updateTrackerDivisionOfficerChannel(divisionData, officersChannel);
+			await updateTrackerDivisionChannels(divisionData, officersChannel, membersChannel);
 		}
 
 		if (divisionData && divisionData.icon) {

--- a/aod-discord-bot.js
+++ b/aod-discord-bot.js
@@ -1656,15 +1656,8 @@ function updateTrackerDivisionData(divisionData, data) {
 }
 
 function updateTrackerDivisionChannel(divisionData, channelType, channel) {
-	const updates = {};
-
-	if (channel) {
-		updates[channelType] = channel.id;
-	}
-
-	if (Object.keys(updates).length === 0) {
-		return;
-	}
+	let updates = {};
+	updates[channelType] = channel.id;
 
 	return updateTrackerDivisionData(divisionData, updates)
 		.then(function() {


### PR DESCRIPTION
Updates the division officer channel method to handle both officer and member channel settings.

The `member_channel` attribute is a new setting and will depend on https://github.com/ClanAODDev/tracker_v3/commit/818c55c257f61a0dfc5467a39a01ba414087f052 being merged