### PR TITLE
Drop logging, fix liveness check

### DIFF
--- a/aod-discord-bot.js
+++ b/aod-discord-bot.js
@@ -4649,7 +4649,7 @@ var lastDate = null;
 var twitchMonitorTimer = null;
 var twitchAccessToken = null;
 var twitchTokenExpiry = 0;
-var twitchStreamWasLive = false;
+var twitchStreamWasLive = null;
 
 function forumSyncTimerCallback() {
 	global.lastForumSync = new Date();
@@ -4721,13 +4721,11 @@ async function twitchMonitorCallback() {
 		});
 		let data = await response.json();
 		let isLive = data.data && data.data.length > 0 && data.data[0].type === 'live';
-		console.log(`Twitch: channel=${config.twitch.channelName} isLive=${isLive} wasLive=${twitchStreamWasLive}`);
 
-		if (isLive && !twitchStreamWasLive) {
+		if (isLive && twitchStreamWasLive === false) {
 			let stream = data.data[0];
 			const guild = client.guilds.resolve(config.guildId);
 			const channel = guild.channels.cache.find(c => c.name === config.twitch.notificationChannel);
-			console.log(`Twitch: posting to ${config.twitch.notificationChannel} found=${!!channel}`);
 			if (channel) {
 				let thumbnailUrl = stream.thumbnail_url.replace('{width}', '400').replace('{height}', '225');
 				let embed = {


### PR DESCRIPTION
Only post if we actually see a move from not live to live. This should stop posts erroneously being made if the bot restarts or crashes mid-stream and we've already posted

Also gitignore jetbrains artifacts